### PR TITLE
tweak: No hours for loadout

### DIFF
--- a/Resources/Prototypes/_NF/Loadouts/base_loadout_effects.yml
+++ b/Resources/Prototypes/_NF/Loadouts/base_loadout_effects.yml
@@ -5,7 +5,8 @@
   - !type:JobRequirementLoadoutEffect
     requirement:
       !type:OverallPlaytimeRequirement
-      time: 43200 # 12 hrs
+      # time: 43200 # 12 hrs
+      time: 1
 
 # Tier 2 generic playtime. 30 hours, 5 full shifts.
 - type: loadoutEffectGroup
@@ -14,8 +15,9 @@
   - !type:JobRequirementLoadoutEffect
     requirement:
       !type:OverallPlaytimeRequirement
-      time: 108000 # 30 hrs
-      
+      # time: 108000 # 30 hrs
+      time: 1
+
 # Tier 3 generic playtime. 50 hours, 8+ full shifts. Premium toy rewards.
 - type: loadoutEffectGroup
   id: ContractorT3
@@ -23,5 +25,6 @@
   - !type:JobRequirementLoadoutEffect
     requirement:
       !type:OverallPlaytimeRequirement
-      time: 180000 # 50 hrs
+      # time: 180000 # 50 hrs
+      time: 1
 


### PR DESCRIPTION

## About the PR
Убирает ограничение на часы для выбора снаряжения должностей в лодауте

## Why / Balance
Так нужно.
