### PR TITLE
Test Event Tweaks

### DIFF
--- a/Content.Server/StationEvents/RampingStationEventSchedulerSystem.cs
+++ b/Content.Server/StationEvents/RampingStationEventSchedulerSystem.cs
@@ -70,6 +70,6 @@ public sealed class RampingStationEventSchedulerSystem : GameRuleSystem<RampingS
         var mod = GetChaosModifier(uid, component);
 
         // 4-12 minutes baseline. Will get faster over time as the chaos mod increases.
-        component.TimeUntilNextEvent = _random.NextFloat(240f / mod, 720f / mod);
+        component.TimeUntilNextEvent = _random.NextFloat(360f / mod, 1080f / mod); // Khorinis test 360|1080, old: _random.NextFloat(240f / mod, 720f / mod)
     }
 }

--- a/Resources/Prototypes/GameRules/roundstart.yml
+++ b/Resources/Prototypes/GameRules/roundstart.yml
@@ -303,6 +303,9 @@
   parent: BaseGameRule
   components:
   - type: BasicStationEventScheduler
+    minMaxEventTiming:
+      min: 360 # 6 mins Khorinis
+      max: 1200 # 20 mins Khorinis
     scheduledGameRules: !type:NestedSelector
       tableId: BasicGameRulesTable
 
@@ -311,7 +314,10 @@
   parent: BaseGameRule
   components:
   - type: RampingStationEventScheduler
-    scheduledGameRules: !type:NestedSelector
+    minMaxEventTiming:
+      min: 360 # 6 mins Khorinis
+      max: 1200 # 20 mins Khorinis
+  scheduledGameRules: !type:NestedSelector
       tableId: BasicGameRulesTable
 
 - type: entity

--- a/Resources/Prototypes/GameRules/roundstart.yml
+++ b/Resources/Prototypes/GameRules/roundstart.yml
@@ -317,7 +317,7 @@
     minMaxEventTiming:
       min: 360 # 6 mins Khorinis
       max: 1200 # 20 mins Khorinis
-  scheduledGameRules: !type:NestedSelector
+    scheduledGameRules: !type:NestedSelector
       tableId: BasicGameRulesTable
 
 - type: entity

--- a/Resources/Prototypes/GameRules/roundstart.yml
+++ b/Resources/Prototypes/GameRules/roundstart.yml
@@ -314,9 +314,8 @@
   parent: BaseGameRule
   components:
   - type: RampingStationEventScheduler
-    minMaxEventTiming:
-      min: 360 # 6 mins Khorinis
-      max: 1200 # 20 mins Khorinis
+    averageChaos: 10 # Khorinis test (base 12)
+    averageEndTime: 420 # Khorinis test (base 90)
     scheduledGameRules: !type:NestedSelector
       tableId: BasicGameRulesTable
 

--- a/Resources/Prototypes/_NF/Events/nf_bluespace_grids_events.yml
+++ b/Resources/Prototypes/_NF/Events/nf_bluespace_grids_events.yml
@@ -13,8 +13,8 @@
     duration: 1350
     maxDuration: 1560
     reoccurrenceDelay: 480 # 8 hours
-    requiredJobs:
-      Sheriff: 1
+    # requiredJobs: # Khorinis
+    #   Sheriff: 1 # Khorinis
   - type: BluespaceErrorRule
     groups:
       grid: !type:GridSpawnGroup
@@ -55,8 +55,8 @@
     duration: 1020
     maxDuration: 1350
     reoccurrenceDelay: 480 # 8 hours
-    requiredJobs:
-      Sheriff: 1
+    # requiredJobs: # Khorinis
+    #   Sheriff: 1 # Khorinis
   - type: BluespaceErrorRule
     groups:
       grid: !type:GridSpawnGroup
@@ -93,13 +93,13 @@
     warningAnnouncement: station-event-bluespace-vault-warning-announcement
     endAnnouncement: station-event-bluespace-vault-end-announcement
     earliestStart: 100
-    maximumPlayers: 30
+    maximumPlayers: 5 # Khorinis - old 30
     weight: 5
     duration: 590
     maxDuration: 780
     reoccurrenceDelay: 480 # 8 hours
-    requiredJobs:
-      Sheriff: 1
+    # requiredJobs: # Khorinis
+    #   Sheriff: 1 # Khorinis
   - type: BluespaceErrorRule
     groups:
       grid: !type:GridSpawnGroup
@@ -136,7 +136,7 @@
     warningAnnouncement: station-event-bluespace-generic-ftl-warning-announcement
     endAnnouncement: station-event-bluespace-generic-ftl-end-announcement
     earliestStart: 80
-    minimumPlayers: 15
+    # minimumPlayers: 15 # Khorinis
     weight: 1
     duration: 1800
     maxDuration: 2400
@@ -175,7 +175,7 @@
     warningAnnouncement: station-event-bluespace-generic-ftl-warning-announcement
     endAnnouncement: station-event-bluespace-generic-ftl-end-announcement
     earliestStart: 100
-    minimumPlayers: 15
+    # minimumPlayers: 15 # Khorinis
     weight: 1
     duration: 900
     maxDuration: 1200
@@ -214,7 +214,7 @@
     warningAnnouncement: station-event-bluespace-generic-ftl-warning-announcement
     endAnnouncement: station-event-bluespace-generic-ftl-end-announcement
     earliestStart: 80
-    minimumPlayers: 15
+    # minimumPlayers: 15 # Khorinis
     weight: 1
     duration: 1800
     maxDuration: 2400


### PR DESCRIPTION
## About the PR
Изменены критерии прока ивентов
-Убраны критерии по минимальному онлайну для ивентов: тайника, большого и малого хранилища.
-Убраны критерии по обязательному наличию шерифа ДСБФ для ивентов: синди шипа, шипа магов, шипа культистов. 
Так же в тестовом порядке увеличены промежутки между малыми ивентами в два раза от стандартного. 